### PR TITLE
Changes to pyFMS_util functions and add bind(C) to cFMS

### DIFF
--- a/clibFMS/cFMS.F90
+++ b/clibFMS/cFMS.F90
@@ -1,6 +1,6 @@
 module cFMS_mod
 
-  use FMS
+  use FMS, only : fms_init, fms_mpp_domains_init, fms_mpp_domains_define_domains, FmsMppDomain2D, fms_string_utils_c2f_string
   use iso_c_binding
 
   implicit none
@@ -23,14 +23,14 @@ contains
   end function cFMS_get_domain
 
 
-  subroutine cFMS_fms_init(localcomm, alt_input_nml_path_ptr)
+  subroutine cFMS_fms_init(localcomm, alt_input_nml_path_ptr) bind(C)
 
     implicit none
-    integer, intent(in), optional :: localcomm
+    integer, intent(in), optional     :: localcomm
     type(c_ptr), intent(in), optional :: alt_input_nml_path_ptr
-
+    
     character(100) :: alt_input_nml_path = input_nml_path
-
+    
     if(present(alt_input_nml_path_ptr)) &
          alt_input_nml_path = fms_string_utils_c2f_string(alt_input_nml_path_ptr)
     
@@ -43,7 +43,7 @@ contains
        n_pelist, n_xextent, n_yextent, n1_maskmap, n2_maskmap, n_memory_size, &
        pelist, xflags, yflags, xhalo, yhalo, xextent, yextent, maskmap, name_ptr, symmetry, &
        memory_size, whalo, ehalo, shalo, nhalo, is_mosaic, tile_count, tile_id,             &
-       complete, x_cyclic_offset, y_cyclic_offset)
+       complete, x_cyclic_offset, y_cyclic_offset) bind(C)
 
     implicit none
 

--- a/pylibFMS/pyFMS.py
+++ b/pylibFMS/pyFMS.py
@@ -9,6 +9,21 @@ from pyFMS_utils import *
 #TODO:  get localcomm from pace
 #TODO:  define domain via GFDL_atmos_cubed_sphere/tools/fv_mp_mod
 
+
+def fms_init( pylibFMS: c.CDLL=None, localcomm: int=None, alt_input_nml_path: str="input/input.nml") :
+
+    _fms_init = pylibFMS.cfms_fms_init
+
+    localcomm_p, localcomm_t = setscalar_Cint32(localcomm)
+
+    alt_input_nml_path_p, alt_input_nml_path_t = set_Cchar(alt_input_nml_path)
+    
+    _fms_init.argtypes = [ localcomm_t, alt_input_nml_path_t ]
+    _fms_init.restype  = None
+    
+    _fms_init( localcomm_p, alt_input_nml_path_p )
+
+
 @dataclasses.dataclass
 class FMS() :
 
@@ -26,54 +41,48 @@ class FMS() :
             raise ValueError(f"Library {self.pylibFMS_path} does not exist")
 
         if self.pylibFMS == None : self.pylibFMS = c.cdll.LoadLibrary(self.pylibFMS_path)
-    
-        _fms_init = getattr(self.pylibFMS, "__cfms_mod_MOD_cfms_fms_init")
-        localcomm, localcomm_t = setargs_Cint32(self.localcomm)
-        alt_input_nml_path, alt_input_nml_path_t = setargs_Cchar(self.alt_input_nml_path)
-
-        _fms_init.argtypes = [ localcomm_t, alt_input_nml_path_t ]
-        _fms_init.restype = None
-
-        _fms_init(localcomm, alt_input_nml_path)
+        
+        fms_init(self.pylibFMS, self.localcomm, self.alt_input_nml_path)
         
         
-    def define_domains2d(self, global_indices, layout, pelist=None,
-                         xflags=None, yflags=None, xhalo=None, yhalo=None, xextent=None, yextent=None,
-                         maskmap=None, name=None, symmetry=None, memory_size=None,
+    def define_domains2d(self, global_indices, layout, pelist=[None],
+                         xflags=None, yflags=None, xhalo=None, yhalo=None, xextent=[None], yextent=[None],
+                         maskmap=[None], name=None, symmetry=None, memory_size=[None],
                          whalo=None, ehalo=None, shalo=None, nhalo=None, is_mosaic=None, tile_count=None,
                          tile_id=None, complete=None, x_cyclic_offset=None, y_cyclic_offset=None) :
 
-        _mpp_define_domains2d = getattr(self.libFMS, "__cfms_mod_MOD_cfms_define_domains2d")
-        
-        global_indices, global_indices_t = setargs_Cint32(global_indices)
-        layout, layout_t = setargs_Cint32(layout)
-        pelist, pelist_t = setargs_Cint32(pelist) #array(:)
-        xflags, xflags_t = setargs_Cint32(xflags)
-        yflags, yflags_t = setargs_Cint32(xflags)
-        xhalo, xhalo_t = setargs_Cint32(xflags)
-        yhalo, yhalo_t = setargs_Cint32(yflags)
-        xextent, xextent_t = setargs_Cint32(xextent) #array(:)
-        yextent, yextent_t = setargs_Cint32(yextent)
-        maskmap, maskmap_t = setargs_Cbool(maskmap) #array(:)
-        name, name_t = setargs_Cchar(name)
-        symmetry, symmetry_t = setargs_Cbool(symmetry)
-        memory_size, memory_size_t = setargs_Cint32(memory_size) #array(:,:)
-        whalo, whalo_t = setargs_Cint32(whalo)
-        ehalo, ehalo_t = setargs_Cint32(ehalo)
-        shalo, shalo_t = setargs_Cint32(shalo)
-        nhalo, nhalo_t = setargs_Cint32(nhalo)
-        is_mosaic, is_mosaic_t = setargs_Cbool(is_mosaic)
-        tile_count, tile_count_t = setargs_Cint32(tile_count)
-        tile_id, tile_id_t = setargs_Cint32(tile_id)
-        complete, complete_t = setargs_Cbool(complete)
-        x_cyclic_offset, x_cyclic_offset_t = setargs_Cint32(x_cyclic_offset)
-        y_cyclic_offset, y_cyclic_offset_t = setargs_Cint32(y_cyclic_offset)    
+        _mpp_define_domains2d = self.pylibFMS.cfms_define_domains2d
 
-        npelist, npelist_t = setargs_size(pelist,1)
-        nxextent, nxextent_t = setargs_size(xextent,1)
-        nyextent, nyextent_t = setargs_size(yextent,1)
-        nmaskmap, nmaskmap_t = setargs_size(maskmap,2)        
-        nmemory_size, nmemory_size_t = setargs_size(memory_size,1)
+        global_indices_p, global_indices_t = setarray_Cint32(global_indices)
+        layout_p, layout_t = setarray_Cint32(layout)
+        
+        pelist_p, pelist_t = setarray_Cint32(pelist)    #array(:)
+        xflags_p, xflags_t = setscalar_Cint32(xflags)
+        yflags_p, yflags_t = setscalar_Cint32(xflags)
+        xhalo_p, xhalo_t = setscalar_Cint32(xflags)
+        yhalo_p, yhalo_t = setscalar_Cint32(yflags)
+        xextent_p, xextent_t = setarray_Cint32(xextent) #array(:)
+        yextent_p, yextent_t = setarray_Cint32(yextent) #array(:)
+        maskmap_p, maskmap_t = setarray_Cbool(maskmap)  #array(:)
+        name_p, name_t       = set_Cchar(name)
+        symmetry_p, symmetry_t       = setscalar_Cbool(symmetry)
+        memory_size_p, memory_size_t = setarray_Cint32(memory_size) #array(:,:)
+        whalo_p, whalo_t = setscalar_Cint32(whalo)
+        ehalo_p, ehalo_t = setscalar_Cint32(ehalo)
+        shalo_p, shalo_t = setscalar_Cint32(shalo)
+        nhalo_p, nhalo_t = setscalar_Cint32(nhalo)
+        is_mosaic_p, is_mosaic_t   = setscalar_Cbool(is_mosaic)
+        tile_count_p, tile_count_t = setscalar_Cint32(tile_count)
+        tile_id_p, tile_id_t   = setscalar_Cint32(tile_id)
+        complete_p, complete_t = setscalar_Cbool(complete)
+        x_cyclic_offset_p, x_cyclic_offset_t = setscalar_Cint32(x_cyclic_offset)
+        y_cyclic_offset_p, y_cyclic_offset_t = setscalar_Cint32(y_cyclic_offset)    
+
+        npelist,  npelist_t  = set_sizevars(pelist,1)
+        nxextent, nxextent_t = set_sizevars(xextent,1)
+        nyextent, nyextent_t = set_sizevars(yextent,1)
+        nmaskmap, nmaskmap_t = set_sizevars(maskmap,2)        
+        nmemory_size, nmemory_size_t = set_sizevars(memory_size,1)
 
         _mpp_define_domains2d.argtypes = [ global_indices_t, layout_t, *npelist_t, *nxextent_t, *nyextent_t,
                                            *nmaskmap_t, *nmemory_size_t, pelist_t, xflags_t, yflags_t,
@@ -82,25 +91,12 @@ class FMS() :
                                            tile_id_t, complete_t, x_cyclic_offset_t, y_cyclic_offset_t ]
 
         _mpp_define_domains2d.restype = None
-
-        _mpp_define_domains2d( global_indices, layout, *npelist, *nxextent, *nyextent,
-                               *nmaskmap, *nmemory_size, pelist, xflags, yflags,
-                               xhalo, yhalo, xextent, yextent, maskmap, name, symmetry,
-                               memory_size, whalo, ehalo, shalo, nhalo, is_mosaic, tile_count,
-                               tile_id, complete, x_cyclic_offset, y_cyclic_offset )
-
-    def get_layout2d(self) :
-
-        _mpp_get_layout2d = getattr(self.libFMS, "__cfms_mod_MOD_cfms_get_layout2d") 
-
-        layout, layout_t = setargs_Cint32([1,1])
-
-        _mpp_get_layout2d.argtypes = [ layout_t ]
-        _mpp_get_layout2d.restype = None
-
-        _mpp_get_layout2d(layout)
-
-        return layout
+        
+        _mpp_define_domains2d( global_indices_p, layout_p, *npelist, *nxextent, *nyextent,
+                               *nmaskmap, *nmemory_size, pelist_p, xflags_p, yflags_p,
+                               xhalo_p, yhalo_p, xextent_p, yextent_p, maskmap_p, name_p, symmetry_p,
+                               memory_size_p, whalo_p, ehalo_p, shalo_p, nhalo_p, is_mosaic_p, tile_count_p,
+                               tile_id_p, complete_p, x_cyclic_offset_p, y_cyclic_offset_p )
 
         
     

--- a/pylibFMS/pyFMS_utils.py
+++ b/pylibFMS/pyFMS_utils.py
@@ -5,56 +5,73 @@ import numpy as np
 import dataclasses
 
 
-def setargs_Cint32(arg) :
-    if arg == None :
-        arg_t = c.POINTER(c.c_int)
+def set_ndpointer(arg, c_type) :
+    return np.ctypeslib.ndpointer( dtype=c_type, shape=np.shape(arg), flags='FORTRAN')
+
+def setarray_Cint32(arg) :    
+    if arg[0] == None :
+        return None, c.POINTER(c.c_int)
     else :
-        arg = [arg] if len(arg) == 0 else arg
-        arg = np.ctypeslib.as_array( np.array(arg, dtype=np.int32) )
-        arg_t = np.ctypeslib.ndpointer( dtype=c.c_int, shape=np.shape(arg), flags='FORTRAN')
+        return arg, set_ndpointer(arg, c.c_int)
+
+def setarray_Cfloat(arg) :
+    if arg[0] == None :
+        return None,  c.POINTER(c.c_float32)
+    else :
+        return arg, set_ndpointer(arg, c.c_float)
     return arg, arg_t
 
 
-def setargs_Cfloat(arg) :
-    if arg == None :
-        arg_t = c.POINTER(c.c_float32)
+def setarray_Cdouble(arg) :
+    if arg[0] == None :
+        return None, c.POINTER(c.c_double)
     else :
-        arg = [arg] if len(arg) == 0 else arg
-        arg = np.ctypeslib.as_array( np.array(arg, dtype=np.float32) )
-        arg_t = np.ctypeslib.ndpointer( dtype=c.c_float, shape=np.shape(arg), flags='FORTRAN')
-    return arg, arg_t
-
-
-def setargs_Cdouble(arg) :
+        return arg, set_ndpointer(arg, c.c_double)
+    
+def set_Cchar(arg) :
     if arg == None :
-        arg_t = c.POINTER(c.c_double)
+        return arg, c.POINTER(c.c_char_p)
     else :
-        arg = [arg] if len(arg) == 0 else arg
-        arg = np.ctypeslib.as_array( np.array(arg, dtype=np.floag64) )
-        arg_t = np.ctypeslib.ndpointer( dtype=c.c_double, shape=np.shape(arg), flags='FORTRAN')
-    return arg, arg_t
+        return c.byref( c.c_char_p( arg.encode('ascii') ) ), c.POINTER(c.c_char_p)
 
-def setargs_Cchar(arg) :
-    if arg == None :
-        arg_t = c.POINTER(c.c_char_p)
+
+def setarray_Cbool(arg) :
+    if arg[0] == None :
+        return None, c.POINTER(c.c_bool)
     else :
-        arg = c.byref( c.c_char_p( arg.encode('ascii') ) )
-        arg_t = c.POINTER(c.c_char_p)
-    return arg, arg_t
+        return arg, set_ndpointer(arg, c.c_bool)
 
 
-def setargs_Cbool(arg) :
+def setscalar_Cint32(arg) :
     if arg == None :
-        arg_t = c.POINTER(c.c_bool)
+        return arg, c.POINTER(c.c_int)
     else :
-        arg = [arg] if len(arg) == 0 else arg
-        arg = np.ctypeslib.as_array( np.array(arg, dtype=np.bool) )
-        arg_t = np.ctypeslib.ndpointer( dtype=c.c_bool, shape=np.shape(arg), flags='FORTRAN')
-    return arg, arg_t
+        return c.byref(c.c_int(arg)), c.POINTER(c.c_int)
 
 
-def setargs_size(arg, ndim) :
+def setscalar_Cfloat(arg) :
     if arg == None :
+        return arg, c.POINTER(c.c_float)
+    else :
+        return c.byref(c.c_float(arg)), c.POINTER(c.c_float)
+
+    
+def setscalar_Cdouble(arg) :
+    if arg == None :
+        return arg, c.POINTER(c.c_double)
+    else :
+        return c.byref(c.c_double(arg)), c.POINTER(c.c_double)
+
+
+def setscalar_Cbool(arg) :
+    if arg == None :
+        return arg, c.POINTER(c.c_double)
+    else :
+        return c.byref(c.c_bool(arg)), c.POINTER(c.c_bool)
+    
+    
+def set_sizevars(arg, ndim) :
+    if arg[0] == None :
         argsize = [ c.byref(c.c_int(1)) for i in range(ndim) ]
         argsize_t = [ c.POINTER(c.c_int) for i in range(ndim) ]
     else :


### PR DESCRIPTION
In this PR,

1.  `bind(C)` has been appended to cFMS wrapper subroutines.  By specifying `use,only` in the module, the `bind(C)` does not de-mangle the the name of the procedure being invoked.  With this change, `getattr` with the mangled name is not required in pyFMS to extract the Fortran subroutine name from pylibFMS.

2.  the `setarg` functions have been hopefully improved.  Separate functions exist for scalar arguments and array arguments.  It should be noted, the setarg functions no longer convert python lists  to numpy arrays.  It will be up to the users to pass in numpy arrays created with the correct dtype specified